### PR TITLE
Add async Bible API service

### DIFF
--- a/Daily Bread/Daily Bread/Core/Bible/Models/BibleVersion.swift
+++ b/Daily Bread/Daily Bread/Core/Bible/Models/BibleVersion.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct BibleVersion: Decodable, Identifiable {
+    let id: String
+    let abbreviation: String
+    let name: String
+    let language: String
+}

--- a/Daily Bread/Daily Bread/Core/Bible/Services/BibleAPI.swift
+++ b/Daily Bread/Daily Bread/Core/Bible/Services/BibleAPI.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum BibleAPI {
+    static let baseURL = URL(string: "https://cdn.jsdelivr.net/gh/wldeh/bible-api/")!
+
+    static func fetchVersions() async throws -> [BibleVersion] {
+        let url = baseURL.appendingPathComponent("bibles/bibles.json")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return try JSONDecoder().decode([BibleVersion].self, from: data)
+    }
+
+    struct Verse: Decodable {
+        let book: String
+        let chapter: Int
+        let verse: Int
+        let text: String
+    }
+
+    static func fetchVerse(version: String, book: String, chapter: Int, verse: Int) async throws -> Verse {
+        let url = baseURL.appendingPathComponent("bibles/\(version)/books/\(book)/chapters/\(chapter)/verses/\(verse).json")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        return try JSONDecoder().decode(Verse.self, from: data)
+    }
+}

--- a/Daily Bread/Daily Bread/Core/Bible/Views/BibleViewModel.swift
+++ b/Daily Bread/Daily Bread/Core/Bible/Views/BibleViewModel.swift
@@ -7,52 +7,45 @@
 
 import SwiftUI
 
+@MainActor
 class BibleViewModel: ObservableObject {
-    
+
     @Published var version = ""
     @Published var book: String = ""
     @Published var chapter: String = ""
     @Published var verse: String = ""
-    
-    
+    @Published var versions: [BibleVersion] = []
+
     init() {
-        fetchBook()
-        fetchChapter()
-        fetchVerse()
-        fetchVersion()
-    }
-    
-    func fetchBook() {
-        self.book = "Genesis"
-    }
-    
-    func fetchChapter() {
-        self.chapter = "1"
-    }
-    
-    func fetchVerse() {
-        let urlString = "https://cdn.jsdelivr.net/gh/wldeh/bible-api/bibles/bibles.json"
-        
-        guard let url = URL(string: urlString) else { return }
-        
-        URLSession.shared.dataTask(with: url) { data, response, error in
-            if let error = error {
-                print(error)
-                return
-            }
-            
-            print("Did receive data: \(data)")
-            
-            guard let data = data else { return }
-            print(data)
-            guard let jsonObject = try? JSONSerialization.jsonObject(with: data) else { return }
-            print("JSON \(jsonObject)")
+        Task {
+            await fetchVersion()
+            await fetchVerse()
         }
-        .resume()
-        self.verse = "12"
     }
-    
-    func fetchVersion() {
-        self.version = "KJV"
+
+    func fetchVerse() async {
+        do {
+            let verseData = try await BibleAPI.fetchVerse(version: version.lowercased().isEmpty ? "kjv" : version.lowercased(),
+                                                         book: "gen",
+                                                         chapter: 1,
+                                                         verse: 1)
+            book = verseData.book
+            chapter = String(verseData.chapter)
+            verse = verseData.text
+        } catch {
+            print("Verse fetch failed: \(error)")
+        }
+    }
+
+    func fetchVersion() async {
+        do {
+            let fetched = try await BibleAPI.fetchVersions()
+            versions = fetched
+            if let first = fetched.first {
+                version = first.abbreviation
+            }
+        } catch {
+            print("Version fetch failed: \(error)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `BibleVersion` model to represent available Bible versions
- Introduce `BibleAPI` service with async functions for versions and verses
- Switch `BibleViewModel` to async/await for retrieving version and verse data

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swiftc Core/Bible/Views/BibleViewModel.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6898a554d0c88321bd166eb724b61d8c